### PR TITLE
Feat/custom user category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules/
 build/
 tmp/
 temp/
-./.env
+.env

--- a/src/apis/controllers/categoryController.ts
+++ b/src/apis/controllers/categoryController.ts
@@ -27,9 +27,9 @@ async function deleteCategory(req: CustomizedRequest, res: Response) {
 }
 async function modifyCategory(req: CustomizedRequest, res: Response) {
 	const { user } = req;
-	const { categoryId, name, isDefault } = req.body;
+	const { categoryId, name } = req.body;
 	if (!user || !categoryId) throw new Error('NOT_FOUND_REQUESTED_ELEMENT');
-	await categoryService.modifyCategory(user, categoryId, name, isDefault);
+	await categoryService.modifyCategory(user, categoryId, name);
 	return res.status(205).json({ message: 'INFORMATION_MODIFIED' });
 	//205 =>     RESET_CONTENT
 }

--- a/src/apis/controllers/categoryController.ts
+++ b/src/apis/controllers/categoryController.ts
@@ -1,0 +1,8 @@
+import * as categoryService from '../services/categoryService';
+
+async function getCategory(userId: number) {}
+async function createCategory(userId: number) {}
+async function deleteCategory(userId: number) {}
+async function modifyCategory(userId: number) {}
+
+export { getCategory, createCategory, deleteCategory, modifyCategory };

--- a/src/apis/controllers/categoryController.ts
+++ b/src/apis/controllers/categoryController.ts
@@ -1,6 +1,7 @@
+import { Request, Response } from 'express';
 import * as categoryService from '../services/categoryService';
 
-async function getCategory(userId: number) {}
+async function getCategory(req: Request, res: Response) {}
 async function createCategory(userId: number) {}
 async function deleteCategory(userId: number) {}
 async function modifyCategory(userId: number) {}

--- a/src/apis/controllers/categoryController.ts
+++ b/src/apis/controllers/categoryController.ts
@@ -1,9 +1,37 @@
 import { Request, Response } from 'express';
+import { CustomizedRequest } from '../utils/IRequest';
 import * as categoryService from '../services/categoryService';
 
-async function getCategory(req: Request, res: Response) {}
-async function createCategory(userId: number) {}
-async function deleteCategory(userId: number) {}
-async function modifyCategory(userId: number) {}
+async function getCategory(req: CustomizedRequest, res: Response) {
+	const result = await categoryService.getCategory(req.user);
+	return res.status(202).json({ message: 'SUCCESS', result });
+}
+async function createCategory(req: CustomizedRequest, res: Response) {
+	//카테고리 만들 때 필요한 것 => ID, Category 명, userId
+	const { user } = req;
+	const { name } = req.body;
+
+	if (!user || !name) throw new Error('NOT_FOUND_REQUESTED_ELEMENT');
+	await categoryService.createCategory(user, name);
+
+	return res.status(201).json({ message: 'CATEGORY_CREATED' });
+}
+async function deleteCategory(req: CustomizedRequest, res: Response) {
+	const { user } = req;
+	const { categoryId } = req.body;
+
+	if (!user || !categoryId) throw new Error('NOT_FOUND_REQUESTED_ELEMENT');
+	await categoryService.deleteCategory(user, categoryId);
+
+	return res.status(204).json({ message: 'CATEGORY_DELETED' });
+}
+async function modifyCategory(req: CustomizedRequest, res: Response) {
+	const { user } = req;
+	const { categoryId, name, isDefault } = req.body;
+	if (!user || !categoryId) throw new Error('NOT_FOUND_REQUESTED_ELEMENT');
+	await categoryService.modifyCategory(user, categoryId, name, isDefault);
+	return res.status(205).json({ message: 'INFORMATION_MODIFIED' });
+	//205 =>     RESET_CONTENT
+}
 
 export { getCategory, createCategory, deleteCategory, modifyCategory };

--- a/src/apis/models/categoryDao.ts
+++ b/src/apis/models/categoryDao.ts
@@ -26,7 +26,7 @@ function createCategory(name: string, userId: number) {
 function deleteCategory(userId: number, categoryId: number | number[]) {
 	return AppDataSource.manager.delete(Category, { id: categoryId, userId });
 }
-function modifyCategoryName(userId: number, categoryId: number, name?: string) {
+function modifyCategory(userId: number, categoryId: number, name?: string) {
 	return AppDataSource.manager.update(
 		Category,
 		{ userId, id: categoryId },
@@ -39,5 +39,5 @@ export {
 	checkCateogryBeforeAction,
 	createCategory,
 	deleteCategory,
-	modifyCategoryName,
+	modifyCategory,
 };

--- a/src/apis/models/categoryDao.ts
+++ b/src/apis/models/categoryDao.ts
@@ -1,0 +1,43 @@
+import AppDataSource from '../../data-source';
+import { Category } from '../../entity/Category';
+
+function getCategory(userId: number) {
+	return AppDataSource.manager.findBy(Category, {
+		userId,
+	});
+}
+
+function checkCateogryBeforeAction(
+	userId: number,
+	categoryId?: number | number[]
+) {
+	return AppDataSource.manager.findBy(Category, {
+		userId,
+		id: categoryId,
+	});
+}
+
+function createCategory(name: string, userId: number) {
+	return AppDataSource.manager.insert(Category, {
+		name,
+		userId,
+	});
+}
+function deleteCategory(userId: number, categoryId: number | number[]) {
+	return AppDataSource.manager.delete(Category, { id: categoryId, userId });
+}
+function modifyCategoryName(userId: number, categoryId: number, name?: string) {
+	return AppDataSource.manager.update(
+		Category,
+		{ userId, id: categoryId },
+		{ name }
+	);
+} // Default 일 때는 조건에 따라 변경되어야 하는데 이를 잘 체크하기
+
+export {
+	getCategory,
+	checkCateogryBeforeAction,
+	createCategory,
+	deleteCategory,
+	modifyCategoryName,
+};

--- a/src/apis/models/userDao.ts
+++ b/src/apis/models/userDao.ts
@@ -32,8 +32,7 @@ async function signup(
 	howTodo.user = user;
 	howTodo.progressDate = new Date();
 
-	await AppDataSource.manager.save(welcomeTodo);
-	await AppDataSource.manager.save(howTodo);
+	await AppDataSource.manager.save([welcomeTodo, howTodo]);
 
 	return user;
 }

--- a/src/apis/routes/categoryRouter.ts
+++ b/src/apis/routes/categoryRouter.ts
@@ -1,4 +1,16 @@
 import * as express from 'express';
 const router = express.Router();
 
+router.post('get');
+router.post('create');
+router.post('delete');
+router.post('modify');
+
 export default router;
+
+//카테고리 get => Todo List와 함께 get하는 과정?
+//카테고리 생성 (최대 개수 5개까지 => 5개가 넘을 경우 에러)
+//카테고리 삭제(default 카테고리인 경우, 삭제되면 안 됨)
+//카테고리 수정 =>
+
+//모든 생성, 수정, 삭제에 해당 유저의 카테고리가 맞는지 확인

--- a/src/apis/routes/categoryRouter.ts
+++ b/src/apis/routes/categoryRouter.ts
@@ -1,10 +1,12 @@
 import * as express from 'express';
+import { checkAuthentication } from '../utils/checkAuthentication';
 const router = express.Router();
+import * as categoryController from '../controllers/categoryController';
 
-router.post('get');
-router.post('create');
-router.post('delete');
-router.post('modify');
+router.get('', checkAuthentication, categoryController.getCategory);
+router.post('/create', checkAuthentication, categoryController.createCategory);
+router.post('/delete', checkAuthentication, categoryController.deleteCategory);
+router.post('/modify', checkAuthentication, categoryController.modifyCategory);
 
 export default router;
 

--- a/src/apis/routes/categoryRouter.ts
+++ b/src/apis/routes/categoryRouter.ts
@@ -4,15 +4,24 @@ const router = express.Router();
 import * as categoryController from '../controllers/categoryController';
 
 router.get('', checkAuthentication, categoryController.getCategory);
+
 router.post('/create', checkAuthentication, categoryController.createCategory);
-router.post('/delete', checkAuthentication, categoryController.deleteCategory);
-router.post('/modify', checkAuthentication, categoryController.modifyCategory);
+
+router.delete(
+	'/delete',
+	checkAuthentication,
+	categoryController.deleteCategory
+);
+
+router.put('/modify', checkAuthentication, categoryController.modifyCategory);
 
 export default router;
 
 //카테고리 get => Todo List와 함께 get하는 과정?
 //카테고리 생성 (최대 개수 5개까지 => 5개가 넘을 경우 에러)
 //카테고리 삭제(default 카테고리인 경우, 삭제되면 안 됨)
-//카테고리 수정 =>
+//카테고리 수정 => 카테고리 이름 수정
+//카테고리 수정 => 카테고리 디폴트 변경하기
+//
 
 //모든 생성, 수정, 삭제에 해당 유저의 카테고리가 맞는지 확인

--- a/src/apis/services/categoryService.ts
+++ b/src/apis/services/categoryService.ts
@@ -1,6 +1,55 @@
-async function getCategory(userId: number) {}
-async function createCategory(userId: number) {}
-async function deleteCategory(userId: number) {}
-async function modifyCategory(userId: number) {}
+import * as categoryDao from '../models/categoryDao';
+
+function getCategory(userId: number) {
+	return categoryDao.getCategory(userId);
+}
+async function createCategory(userId: number, name: string) {
+	/*
+    1. 해당 유저의 category 개수가 5개를 넘지 않는지 체크
+    2. 해당 유저의 중복 이름이 존재하는지 체크 
+    정도??
+    */
+	const checkCategoryCount = await categoryDao.checkCateogryBeforeAction(
+		userId
+	);
+
+	console.log(checkCategoryCount);
+	if (checkCategoryCount.length >= 5)
+		throw new Error('CANNOT_MAKE_BEYOND_MAX_CATEGORY');
+
+	const result = await categoryDao.createCategory(name, userId);
+	console.log(result);
+	return result;
+}
+async function deleteCategory(userId: number, categoryId: number | number[]) {
+	const checkCategoryMadeByUser = await categoryDao.checkCateogryBeforeAction(
+		userId,
+		categoryId
+	);
+
+	if (!checkCategoryMadeByUser.length)
+		throw new Error('CANNOT_FOUND_DATA_ACCORDING_TO_THE_CRITERIA');
+
+	if (checkCategoryMadeByUser[0].isDefault)
+		throw new Error('CAN_NOT_DELETE_DEFAULT_CATEGORY');
+
+	return categoryDao.deleteCategory(userId, categoryId);
+}
+async function modifyCategory(
+	userId: number,
+	categoryId: number,
+	name?: string,
+	isDefault?: boolean
+) {
+	const InfoTocheck = await categoryDao.checkCateogryBeforeAction(
+		userId,
+		categoryId
+	);
+
+	if (!InfoTocheck.length)
+		throw new Error('CANNOT_FOUND_DATA_ACCORDING_TO_THE_CRITERIA');
+
+	await categoryDao.modifyCategoryName(userId, categoryId, name);
+}
 
 export { getCategory, createCategory, deleteCategory, modifyCategory };

--- a/src/apis/services/categoryService.ts
+++ b/src/apis/services/categoryService.ts
@@ -1,0 +1,6 @@
+async function getCategory(userId: number) {}
+async function createCategory(userId: number) {}
+async function deleteCategory(userId: number) {}
+async function modifyCategory(userId: number) {}
+
+export { getCategory, createCategory, deleteCategory, modifyCategory };

--- a/src/apis/services/categoryService.ts
+++ b/src/apis/services/categoryService.ts
@@ -7,7 +7,6 @@ async function createCategory(userId: number, name: string) {
 	/*
     1. 해당 유저의 category 개수가 5개를 넘지 않는지 체크
     2. 해당 유저의 중복 이름이 존재하는지 체크 
-    정도??
     */
 	const checkCategoryCount = await categoryDao.checkCateogryBeforeAction(
 		userId
@@ -38,8 +37,7 @@ async function deleteCategory(userId: number, categoryId: number | number[]) {
 async function modifyCategory(
 	userId: number,
 	categoryId: number,
-	name?: string,
-	isDefault?: boolean
+	name?: string
 ) {
 	const InfoTocheck = await categoryDao.checkCateogryBeforeAction(
 		userId,
@@ -49,7 +47,9 @@ async function modifyCategory(
 	if (!InfoTocheck.length)
 		throw new Error('CANNOT_FOUND_DATA_ACCORDING_TO_THE_CRITERIA');
 
-	await categoryDao.modifyCategoryName(userId, categoryId, name);
+	return categoryDao.modifyCategory(userId, categoryId, name);
+
+	//default category 확인하기
 }
 
 export { getCategory, createCategory, deleteCategory, modifyCategory };

--- a/src/apis/utils/IRequest.ts
+++ b/src/apis/utils/IRequest.ts
@@ -2,4 +2,5 @@ import { Request } from 'express';
 
 export interface CustomizedRequest extends Request {
 	user: number;
+	userEmail: string;
 }

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -5,6 +5,7 @@ import {
 	OneToMany,
 	JoinColumn,
 } from 'typeorm';
+import { Category } from './Category';
 import { Diary } from './Diary';
 import { Todo } from './Todo';
 
@@ -21,6 +22,10 @@ export class User {
 
 	@Column({ type: 'varchar', length: '200', nullable: false })
 	password: string;
+
+	@JoinColumn()
+	@OneToMany(() => Category, (category) => category.userId)
+	categories: Category[];
 
 	@JoinColumn()
 	@OneToMany(() => Diary, (diary) => diary.user)


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 유저의 카테고리를 CRUD 하는 API

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 유저 카테고리 생성
- Default Category 포함 5개 이하만 한 유저가 소유할 수 있도록 함.
2. 유저 카테고리 삭제
- 요청이 들어온 해당 categoryId가 해당 유저의 category인지 확인
- Default Category가 아닌 경우에만 삭제 가능하도록
3. 유저 카테고리 이름 수정
- 요청이 들어온 해당 categoryId가 해당 유저의 category인지 확인
- 이름 수정
4. 유저의 카테고리 리스트 정보 반환
- 요청이 들어온 해당 유저의 카테고리 정보 모두를 반환

<br />

## :: 성장 포인트
- 이전에 API를 생성할 때는 기준을 어떻게 잡아야 할지 정하는 부분이 부족하여 마냥 복잡하게만 짰었던 것 같다. 
- 이번에는 API 작성 시 꼭 필요한 기능인지 아닌지를 스스로 결정하려고 노력했고, 그 이유에 대해 생각해볼 수 있었다.
- 카테고리 수정 API를 작성할 때, Default Category를 설정할 수 있도록 해야된다고만 생각했는데, 이 필요성에 대해 스스로 생각해보며 실제로 왜 필요한 과정인가를 생각할 수 있었다.

<br />

### :: 추가 사항
