### PR TITLE
Feat: Todo CRUD API

### DIFF
--- a/src/apis/controllers/todoController.ts
+++ b/src/apis/controllers/todoController.ts
@@ -1,0 +1,57 @@
+import { Response } from 'express';
+import { CustomizedRequest } from '../utils/IRequest';
+import * as todoService from '../services/todoService';
+import { catchAsync } from '../utils/error';
+
+const getTodoList = catchAsync(
+	async (req: CustomizedRequest, res: Response) => {
+		const { user } = req;
+		const { categoryId, isFinished, progressDate } = req.body;
+
+		const todolist = await todoService.getTodolist(user, req.body);
+		return res.status(200).json({ message: 'INFORMATION_RETURNED', todolist });
+	}
+);
+
+const makeTodo = catchAsync(async (req: CustomizedRequest, res: Response) => {
+	const { user } = req;
+	const { todo, progressDate, categoryId, memo } = req.body;
+
+	if (!user || !todo || !progressDate || !categoryId)
+		throw new Error('UNDEFINED_REQUIRED_INFO');
+
+	const todoList = await todoService.makeTodo(
+		user,
+		categoryId,
+		todo,
+		progressDate,
+		memo
+	);
+
+	return res.status(200).json({ message: 'INFORMATION_RETURNED', todoList });
+});
+
+const deleteTodo = catchAsync(async (req: CustomizedRequest, res: Response) => {
+	//delete 수행시 필요한 것 => What?
+	const { user } = req;
+	const { todoId } = req.body;
+
+	if (!user || !todoId) throw new Error('UNDEFINED_REQUIRED_INFO');
+
+	await todoService.deleteTodo(user, todoId);
+
+	return res.status(204).json({ message: 'TODO_DELETED' });
+});
+
+const modifyTodo = catchAsync(async (req: CustomizedRequest, res: Response) => {
+	const { user } = req;
+	const { todoId, memo, isFinished, todo, progressDate } = req.body;
+
+	if (!user || !todoId) throw new Error('UNDEFINED_REQUIRED_INFO');
+
+	await todoService.modifyTodo(user, todoId);
+
+	return res.status(205).json({ message: 'INFORMATION_MODIFIED' });
+});
+
+export { getTodoList, makeTodo, deleteTodo, modifyTodo };

--- a/src/apis/models/todoDao.ts
+++ b/src/apis/models/todoDao.ts
@@ -1,0 +1,67 @@
+import AppDataSource from '../../data-source';
+import { Todo } from '../../entity/Todo';
+
+function checkMasterOfTodo(todoId: number) {
+	return AppDataSource.manager.findBy(Todo, {
+		todoId,
+	});
+}
+
+function getTodoList(
+	user: number,
+	category?: number,
+	isFinished?: boolean,
+	progressDate?: Date
+) {
+	return AppDataSource.manager.find(Todo, {
+		where: {
+			user: user,
+			category,
+			isFinished,
+			progressDate,
+		},
+		order: {
+			isFinished: 'ASC',
+			id: 'ASC',
+		},
+	});
+}
+// 흠... 들어오는 값과 아닌 값에 따라 where
+async function makeTodo(
+	user: number,
+	category: number,
+	todo: string,
+	progressDate: Date,
+	memo?: string
+) {
+	const todoToSave = await AppDataSource.manager.create(Todo, {
+		user,
+		category,
+		todo,
+		progressDate,
+		memo,
+	});
+
+	await AppDataSource.manager.save(todoToSave);
+
+	return todoToSave;
+}
+function deleteTodo(todoId: number) {
+	return AppDataSource.manager.delete(Todo, todoId);
+}
+function modifyTodo(
+	todoId: number,
+	memo?: string,
+	isFinished?: boolean,
+	todo?: string,
+	progressDate?: Date
+) {
+	return AppDataSource.manager.update(Todo, todoId, {
+		memo,
+		isFinished,
+		todo,
+		progressDate,
+	});
+}
+
+export { checkMasterOfTodo, getTodoList, makeTodo, deleteTodo, modifyTodo };

--- a/src/apis/routes/todoRouter.ts
+++ b/src/apis/routes/todoRouter.ts
@@ -1,4 +1,17 @@
 import * as express from 'express';
 const router = express.Router();
+import * as todoController from '../controllers/todoController';
+import { checkAuthentication } from '../utils/checkAuthentication';
+
+router.get('', checkAuthentication, todoController.getTodoList);
+router.post('', checkAuthentication, todoController.makeTodo);
+router.delete('', checkAuthentication, todoController.deleteTodo);
+router.put('', checkAuthentication, todoController.modifyTodo);
 
 export default router;
+
+//Todolist 반환 [get] endpoint: "/todo" => todo
+// => Todolist 반환 시, 날짜, 완료 여부에 따라 필터링 필요
+//Todolist 생성 [Post] endpoint: "/todo" => todo
+//Todolist 수정 [Put] endpoint: "/todo" => todo, memo, isFinished, progressDate, categoryId  []
+//Todolist 삭제 [delete] endpoint: "/todo" => todo

--- a/src/apis/services/todoService.ts
+++ b/src/apis/services/todoService.ts
@@ -1,0 +1,42 @@
+import * as todoDao from '../models/todoDao';
+
+function getTodolist(userId: number, reqBody: conditionToSelect) {
+	console.log(reqBody);
+	// return todoDao.getTodoList(userId, reqBody);
+}
+interface conditionToSelect {
+	category: number;
+	isFinished: boolean;
+	progressDate: Date;
+}
+async function makeTodo(
+	user: number,
+	category: number,
+	todo: string,
+	progressDate: Date,
+	memo?: string
+) {
+	return todoDao.makeTodo(user, category, todo, progressDate, memo);
+}
+async function deleteTodo(user: number, todoId: number) {
+	const [checkTodo] = await todoDao.checkMasterOfTodo(todoId);
+	if (checkTodo.userId !== user) throw new Error(`CANNOT_DELETE_OTHER'S`);
+
+	return todoDao.deleteTodo(todoId);
+	// todoId 와 userId => 해당 엔티티가 있는지 확인 후 삭제과정
+}
+async function modifyTodo(
+	user: number,
+	todoId: number,
+	memo?: string,
+	isFinished?: boolean,
+	todo?: string,
+	progressDate?: Date
+) {
+	const checkTodo = await todoDao.checkMasterOfTodo(todoId);
+	if (checkTodo.userId !== user) throw new Error(`CANNOT_DELETE_OTHER'S`);
+
+	return todoDao.modifyTodo(todoId, memo, isFinished, todo, progressDate);
+}
+
+export { getTodolist, makeTodo, deleteTodo, modifyTodo };

--- a/src/apis/utils/error.ts
+++ b/src/apis/utils/error.ts
@@ -1,6 +1,12 @@
 import { NextFunction, Request, Response } from 'express';
 import { CustomizedError } from './IError';
 
+const catchAsync = (func: Function) => {
+	return (req: Request, res: Response, next: NextFunction) => {
+		func(req, res, next).catch((error: Error) => next(error));
+	};
+};
+
 function globalErrorHandler(
 	err: CustomizedError,
 	req: Request,
@@ -12,4 +18,4 @@ function globalErrorHandler(
 	res.status(err.statusCode).json({ message: err.message });
 }
 
-export default globalErrorHandler;
+export { catchAsync, globalErrorHandler };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import * as cors from 'cors';
 import * as morgan from 'morgan';
 import routes from './apis/routes';
 import AppDataSource from './data-source';
-import globalErrorHandler from './apis/utils/error';
+import { globalErrorHandler } from './apis/utils/error';
 
 const app = express();
 


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- todolist를 CRUD 하는 API 작성


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. todo 리스트 반환
- 필터링(category, 완료여부, 날짜) 기능 구현 : 자신이 선택한 카테고리별 필터링 가능하게, 하지만 날짜 필터는 상시 적용되어야 함.
2. todo 추가하기
3. todo 삭제하기
- 해당 todo가 해당 user의 것이 맞는지 검증하는 서비스 로직
- 해당 과정을 거쳤을 때, todo에 대한 리스트를 바로 반환해주는 것은 어떨까 고민이 들었음.
4. todo 수정하기
- 해당 todo가 해당 user의 것이 맞는지 검증하는 서비스 로직

<br />

## :: 성장 포인트
- typeorm의 EntityManager 메소드들을 어떤 상황에서 어떻게 활용할 수 있는지 깨우친 것 같다.
- 이전 프로젝트에서 Entity들의 관계가 복잡하고, 테이블, 컬럼명 등의 문제와 entity 메소드를 활용할 수 없던 개개인들의 능력 때문에 raw query를 사용하였어서 아쉬움이 있었다.
- 현재는 이 entity manager들이 어떤 값을 인자로 받는지 등을 하나둘씩 알아가며 프로젝트를 진행해가기 때문에 재미도 있고, 갈수록 이 entity manager에 대한 이해가 빨라지고 있다.

<br />

### :: 추가 사항
- typeorm 해당 키값을 조사해서 필요치 않은 키값이 들어왔을 때, 오류를 내는 Middleware 추가해야 될 듯
- 이유 : API 내 키값들을 이용하여 바로 Dao단에서 사용할 수 있게 만들고 싶으나, 원치 않은 키값이 발생할 경우, 이에 대한 에러가 발생할 것
- 그 전에 이를 체크해줄 수 있다면 좋을 듯

- todo 가 수정되거나 삭제되었을 때의 이후 작동 메커니즘이 궁금했고, 이후 다른 기술 스택으로 변경하는 과정을 거치며 이에 대하여 알아보아야 겠다.
- 이후 변경되는 서비스 로직에 대해서는 지속적으로 업데이트할 것

