### PR TITLE
Feat/diary api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
          "version": "0.0.1",
          "dependencies": {
             "@types/bcrypt": "^5.0.0",
+            "@types/dateformat": "^5.0.0",
             "@types/jsonwebtoken": "^9.0.1",
             "bcrypt": "^5.1.0",
             "cors": "^2.8.5",
+            "dateformat": "^5.0.3",
             "dotenv": "^16.0.3",
             "express": "^4.18.2",
             "jsonwebtoken": "^9.0.0",
@@ -133,6 +135,11 @@
          "dependencies": {
             "@types/node": "*"
          }
+      },
+      "node_modules/@types/dateformat": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
+         "integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA=="
       },
       "node_modules/@types/express": {
          "version": "4.17.17",
@@ -694,6 +701,14 @@
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/date-fns"
+         }
+      },
+      "node_modules/dateformat": {
+         "version": "5.0.3",
+         "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+         "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+         "engines": {
+            "node": ">=12.20"
          }
       },
       "node_modules/debug": {
@@ -2359,6 +2374,11 @@
             "@types/node": "*"
          }
       },
+      "@types/dateformat": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
+         "integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA=="
+      },
       "@types/express": {
          "version": "4.17.17",
          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -2783,6 +2803,11 @@
          "version": "2.29.3",
          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
          "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      },
+      "dateformat": {
+         "version": "5.0.3",
+         "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+         "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA=="
       },
       "debug": {
          "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
    },
    "dependencies": {
       "@types/bcrypt": "^5.0.0",
+      "@types/dateformat": "^5.0.0",
       "@types/jsonwebtoken": "^9.0.1",
       "bcrypt": "^5.1.0",
       "cors": "^2.8.5",
+      "dateformat": "^5.0.3",
       "dotenv": "^16.0.3",
       "express": "^4.18.2",
       "jsonwebtoken": "^9.0.0",

--- a/src/apis/controllers/diaryController.ts
+++ b/src/apis/controllers/diaryController.ts
@@ -1,0 +1,52 @@
+import { Response } from 'express';
+import * as diaryService from '../services/diaryService';
+import { catchAsync } from '../utils/error';
+import { CustomizedRequest } from '../utils/IRequest';
+
+const getDiaries = catchAsync(async (req: CustomizedRequest, res: Response) => {
+	//userId를 받아서 이에 해당하는 다이어리 가져오기.
+	//offset과 limit을 주면 좋을 것 같고, 최신순으로 order를 주었으면!
+	//프론트 단 화면을 상상해보자면, 페이지네이션을 사용하였으면 좋겠음!
+	//그렇기 때문에 해당 user의 총 일기 갯수도 반환하는 것이 좋겠음!
+
+	//diary에 날짜 필터가 있으면 참 좋을 것 같은데, 기간 내로 할지, 하루하루로 할 지 못 정하겠어.
+	// diary랑 todo랑 같이 반환할 수 있으면 참 좋을텐데 이걸 어떻게 할까
+	const { user } = req;
+	const { offset } = req.params;
+
+	const result = await diaryService.getDiaries(user, +offset);
+	//프론트에서 페이지 네이션에 알맞은 값을 보내줄지, 아니면 백에서 처리할 지를 골라야함.
+
+	return res.status(200).json({ message: 'INFORMATION_RETURNED', result });
+});
+const writeDiaries = catchAsync(
+	async (req: CustomizedRequest, res: Response) => {
+		const { user } = req;
+		const { title, content, date } = req.body;
+
+		const diary = await diaryService.writeDiaries(user, title, content, date);
+
+		return res.status(201).json({ message: 'DIARY_CREATED', diary });
+	}
+);
+const deleteDiary = catchAsync(
+	async (req: CustomizedRequest, res: Response) => {
+		const { user } = req;
+		const { diaryId } = req.params;
+
+		await diaryService.deleteDiary(user, +diaryId);
+		return res.status(204).json({ message: 'DIARY_DELETED' });
+	}
+);
+const rewriteDiaries = catchAsync(
+	async (req: CustomizedRequest, res: Response) => {
+		const { user } = req;
+		const { diaryId, title, content } = req.body;
+
+		await diaryService.rewriteDiaries(user, diaryId, title, content);
+
+		return res.status(205).json({ message: 'DIARY_MODIFIED' });
+	}
+);
+
+export { getDiaries, writeDiaries, deleteDiary, rewriteDiaries };

--- a/src/apis/controllers/diaryController.ts
+++ b/src/apis/controllers/diaryController.ts
@@ -12,7 +12,7 @@ const getDiaries = catchAsync(async (req: CustomizedRequest, res: Response) => {
 	//diary에 날짜 필터가 있으면 참 좋을 것 같은데, 기간 내로 할지, 하루하루로 할 지 못 정하겠어.
 	// diary랑 todo랑 같이 반환할 수 있으면 참 좋을텐데 이걸 어떻게 할까
 	const { user } = req;
-	const { offset } = req.params;
+	const { offset } = req.query;
 
 	const result = await diaryService.getDiaries(user, +offset);
 	//프론트에서 페이지 네이션에 알맞은 값을 보내줄지, 아니면 백에서 처리할 지를 골라야함.

--- a/src/apis/models/diaryDao.ts
+++ b/src/apis/models/diaryDao.ts
@@ -1,0 +1,57 @@
+//userId를 받아서 이에 해당하는 다이어리 가져오기.
+//offset과 limit을 주면 좋을 것 같고, 최신순으로 order를 주었으면!
+//프론트 단 화면을 상상해보자면, 페이지네이션을 사용하였으면 좋겠음!
+
+import AppDataSource from '../../data-source';
+import { Diary } from '../../entity/Diary';
+const checkDiaryOfMaster = async (diaryId: number) => {
+	return AppDataSource.manager.find(Diary, diaryId);
+};
+//그렇기 때문에 해당 user의 총 일기 갯수도 반환하는 것이 좋겠음!
+const getDiaries = async (user: number, offset: number) => {
+	return AppDataSource.manager.find(Diary, { user, skip: offset, take: 10 });
+};
+
+const getCountForPagenation = (user: number) => {
+	return AppDataSource.manager.countBy(Diary, { user });
+};
+
+const writeDiaries = async (
+	user: number,
+	title: string,
+	content: string,
+	date: Date
+) => {
+	const diaryToSave = await AppDataSource.manager.create(Diary, {
+		user,
+		title,
+		content,
+	});
+
+	await AppDataSource.manager.save(diaryToSave);
+
+	return diaryToSave;
+};
+const deleteDiary = async (diaryId: number) => {
+	return AppDataSource.manager.delete(Diary, diaryId);
+};
+
+const rewriteDiaries = async (
+	diaryId: number,
+	title: string,
+	content: string
+) => {
+	return AppDataSource.manager.update(Diary, diaryId, {
+		title,
+		content,
+	});
+};
+
+export {
+	checkDiaryOfMaster,
+	getDiaries,
+	getCountForPagenation,
+	writeDiaries,
+	deleteDiary,
+	rewriteDiaries,
+};

--- a/src/apis/models/diaryDao.ts
+++ b/src/apis/models/diaryDao.ts
@@ -4,47 +4,75 @@
 
 import AppDataSource from '../../data-source';
 import { Diary } from '../../entity/Diary';
-const checkDiaryOfMaster = async (diaryId: number) => {
-	return AppDataSource.manager.find(Diary, diaryId);
-};
-//그렇기 때문에 해당 user의 총 일기 갯수도 반환하는 것이 좋겠음!
-const getDiaries = async (user: number, offset: number) => {
-	return AppDataSource.manager.find(Diary, { user, skip: offset, take: 10 });
+import { IModifyType } from '../utils/IResponse';
+
+const checkDiaryOfMaster = async (diaryId: number): Promise<Diary[]> => {
+	return AppDataSource.manager.find(Diary, {
+		where: {
+			id: diaryId,
+		},
+		relations: {
+			user: true,
+		},
+	});
 };
 
-const getCountForPagenation = (user: number) => {
+const getDiaries = async (user: number, offset: number): Promise<Diary[]> => {
+	return AppDataSource.manager.find(Diary, {
+		select: {
+			id: true,
+			title: true,
+			content: true,
+			targetDate: true,
+		},
+		relations: {
+			user: true,
+		},
+		where: {
+			'user.id': user,
+		},
+	});
+}; // user 테이블 join 시 password 함께 반환되는 문제 해결 필요.
+//그렇기 때문에 해당 user의 총 일기 갯수도 반환하는 것이 좋겠음!
+const getCountForPagenation = (user: number): Promise<number> => {
 	return AppDataSource.manager.countBy(Diary, { user });
-};
+}; // 개수 타입 어떻게 나오는지 확인해야 함
 
 const writeDiaries = async (
 	user: number,
 	title: string,
 	content: string,
 	date: Date
-) => {
+): Promise<Diary> => {
 	const diaryToSave = await AppDataSource.manager.create(Diary, {
 		user,
 		title,
 		content,
+		targetDate: date,
 	});
 
 	await AppDataSource.manager.save(diaryToSave);
 
 	return diaryToSave;
 };
+
 const deleteDiary = async (diaryId: number) => {
-	return AppDataSource.manager.delete(Diary, diaryId);
+	const result = await AppDataSource.manager.delete(Diary, diaryId);
+
+	return result;
 };
 
 const rewriteDiaries = async (
 	diaryId: number,
 	title: string,
 	content: string
-) => {
-	return AppDataSource.manager.update(Diary, diaryId, {
+): Promise<IModifyType> => {
+	const result = await AppDataSource.manager.update(Diary, diaryId, {
 		title,
 		content,
 	});
+	console.log(result);
+	return result;
 };
 
 export {

--- a/src/apis/models/userDao.ts
+++ b/src/apis/models/userDao.ts
@@ -9,7 +9,7 @@ async function signup(
 	password: string
 ): Promise<User> {
 	// const user = new User();
-	const user = AppDataSource.manager.create(User, {
+	const user = await AppDataSource.manager.create(User, {
 		name,
 		email,
 		password,
@@ -17,7 +17,7 @@ async function signup(
 
 	await AppDataSource.manager.save(user);
 
-	const defaultCategory = AppDataSource.manager.create(Category, {
+	const defaultCategory = await AppDataSource.manager.create(Category, {
 		name,
 		user: user.id,
 		isDefault: true,
@@ -25,17 +25,19 @@ async function signup(
 
 	await AppDataSource.manager.save(defaultCategory);
 
-	const welcomeTodo = new Todo();
-	welcomeTodo.category = defaultCategory;
-	welcomeTodo.todo = 'todoIT에 오신 걸 환영합니다!';
-	welcomeTodo.user = user;
-	welcomeTodo.progressDate = new Date();
+	const welcomeTodo = await AppDataSource.manager.create(Todo, {
+		category: defaultCategory.id,
+		todo: 'todoIT에 오신 걸 환영합니다!',
+		user,
+		progressDate: new Date(),
+	});
 
-	const howTodo = new Todo();
-	howTodo.category = defaultCategory;
-	howTodo.todo = '카테고리별 할일을 추가하시거나, 일기를 작성하실 수 있습니다!';
-	howTodo.user = user;
-	howTodo.progressDate = new Date();
+	const howTodo = await AppDataSource.manager.create(Todo, {
+		category: defaultCategory.id,
+		todo: '카테고리별 할일을 추가하시거나, 일기를 작성하실 수 있습니다!',
+		user,
+		progressDate: new Date(),
+	});
 
 	await AppDataSource.manager.save([welcomeTodo, howTodo]);
 

--- a/src/apis/models/userDao.ts
+++ b/src/apis/models/userDao.ts
@@ -8,16 +8,21 @@ async function signup(
 	email: string,
 	password: string
 ): Promise<User> {
-	const user = new User();
-	user.name = name;
-	user.email = email;
-	user.password = password;
+	// const user = new User();
+	const user = AppDataSource.manager.create(User, {
+		name,
+		email,
+		password,
+	});
+
 	await AppDataSource.manager.save(user);
 
-	const defaultCategory = new Category();
-	defaultCategory.name = '기본';
-	defaultCategory.userId = user;
-	defaultCategory.isDefault = true;
+	const defaultCategory = AppDataSource.manager.create(Category, {
+		name,
+		user: user.id,
+		isDefault: true,
+	});
+
 	await AppDataSource.manager.save(defaultCategory);
 
 	const welcomeTodo = new Todo();

--- a/src/apis/routes/diaryRouter.ts
+++ b/src/apis/routes/diaryRouter.ts
@@ -5,7 +5,7 @@ import * as diaryController from '../controllers/diaryController';
 
 router.get('', checkAuthentication, diaryController.getDiaries);
 router.post('', checkAuthentication, diaryController.writeDiaries);
-router.delete('', checkAuthentication, diaryController.deleteDiary);
+router.delete('/:diaryId', checkAuthentication, diaryController.deleteDiary);
 router.put('', checkAuthentication, diaryController.rewriteDiaries);
 
 export default router;

--- a/src/apis/routes/diaryRouter.ts
+++ b/src/apis/routes/diaryRouter.ts
@@ -1,4 +1,11 @@
 import * as express from 'express';
 const router = express.Router();
+import { checkAuthentication } from '../utils/checkAuthentication';
+import * as diaryController from '../controllers/diaryController';
+
+router.get('', checkAuthentication, diaryController.getDiaries);
+router.post('', checkAuthentication, diaryController.writeDiaries);
+router.delete('', checkAuthentication, diaryController.deleteDiary);
+router.put('', checkAuthentication, diaryController.rewriteDiaries);
 
 export default router;

--- a/src/apis/services/diaryService.ts
+++ b/src/apis/services/diaryService.ts
@@ -1,6 +1,12 @@
+import { Diary } from '../../entity/Diary';
 import * as diaryDao from '../models/diaryDao';
+import { IDeleteType, IModifyType } from '../utils/IResponse';
+import { ReturnGetDiaryDtoAtService } from '../utils/ReturnDTO';
 
-const getDiaries = async (user: number, skip: number) => {
+const getDiaries = async (
+	user: number,
+	skip: number
+): Promise<ReturnGetDiaryDtoAtService> => {
 	const diaryList = await diaryDao.getDiaries(user, skip);
 	const countByUser = await diaryDao.getCountForPagenation(user);
 
@@ -11,7 +17,7 @@ const writeDiaries = async (
 	title: string,
 	content: string,
 	date?: Date
-) => {
+): Promise<Diary> => {
 	if (!date) {
 		date = new Date();
 	}
@@ -19,19 +25,29 @@ const writeDiaries = async (
 	const diary = await diaryDao.writeDiaries(user, title, content, date);
 	return diary;
 };
-const deleteDiary = async (user: number, diaryId: number) => {
+
+const deleteDiary = async (
+	user: number,
+	diaryId: number
+): Promise<IDeleteType> => {
 	const [diaryById] = await diaryDao.checkDiaryOfMaster(diaryId);
-	if (diaryById.user !== user) throw new Error(`CANNOT_DELETE_OTHER'S_DIARY`);
+
+	if (diaryById.user.id !== user)
+		throw new Error(`CANNOT_DELETE_OTHER'S_DIARY`);
+
 	return await diaryDao.deleteDiary(diaryId);
 };
+
 const rewriteDiaries = async (
 	user: number,
 	diaryId: number,
 	title?: string,
 	content?: string
-) => {
+): Promise<IModifyType> => {
 	const [diaryById] = await diaryDao.checkDiaryOfMaster(diaryId);
-	if (diaryById.user !== user) throw new Error(`CANNOT_MODIFY_OTHER'S_DIARY`);
+
+	if (diaryById.user.id !== user)
+		throw new Error(`CANNOT_MODIFY_OTHER'S_DIARY`);
 
 	return await diaryDao.rewriteDiaries(diaryId, title, content);
 };

--- a/src/apis/services/diaryService.ts
+++ b/src/apis/services/diaryService.ts
@@ -1,0 +1,39 @@
+import * as diaryDao from '../models/diaryDao';
+
+const getDiaries = async (user: number, skip: number) => {
+	const diaryList = await diaryDao.getDiaries(user, skip);
+	const countByUser = await diaryDao.getCountForPagenation(user);
+
+	return { diaryList, countByUser };
+};
+const writeDiaries = async (
+	user: number,
+	title: string,
+	content: string,
+	date?: Date
+) => {
+	if (!date) {
+		date = new Date();
+	}
+
+	const diary = await diaryDao.writeDiaries(user, title, content, date);
+	return diary;
+};
+const deleteDiary = async (user: number, diaryId: number) => {
+	const [diaryById] = await diaryDao.checkDiaryOfMaster(diaryId);
+	if (diaryById.user !== user) throw new Error(`CANNOT_DELETE_OTHER'S_DIARY`);
+	return await diaryDao.deleteDiary(diaryId);
+};
+const rewriteDiaries = async (
+	user: number,
+	diaryId: number,
+	title?: string,
+	content?: string
+) => {
+	const [diaryById] = await diaryDao.checkDiaryOfMaster(diaryId);
+	if (diaryById.user !== user) throw new Error(`CANNOT_MODIFY_OTHER'S_DIARY`);
+
+	return await diaryDao.rewriteDiaries(diaryId, title, content);
+};
+
+export { getDiaries, writeDiaries, deleteDiary, rewriteDiaries };

--- a/src/apis/utils/IResponse.ts
+++ b/src/apis/utils/IResponse.ts
@@ -1,0 +1,8 @@
+export interface IDeleteType {
+	raw: [];
+	affected: number;
+}
+
+export interface IModifyType extends IDeleteType {
+	generatedMaps: [];
+}

--- a/src/apis/utils/ReturnDTO.ts
+++ b/src/apis/utils/ReturnDTO.ts
@@ -1,0 +1,7 @@
+import { Diary } from '../../entity/Diary';
+
+// Diary
+export class ReturnGetDiaryDtoAtService {
+	diaryList: Diary[];
+	countByUser: number;
+}

--- a/src/apis/utils/checkAuthentication.ts
+++ b/src/apis/utils/checkAuthentication.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import * as jwt from 'jsonwebtoken';
+import 'dotenv/config';
 import { CustomizedRequest } from './IRequest';
 
 export function checkAuthentication(

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,11 +21,10 @@ app.get('/ping', async (req: Request, res: Response) => {
 	return res.status(200).json({ message: 'PONG' });
 });
 
-const start = (): void => {
+const start = () => {
 	try {
-		app.listen(3000, () => {
-			console.log('SERVER IS LISTENING ON PORT 3000');
-		});
+		app.listen(3000, () => console.log('SERVER IS LISTENING ON PORT 3000'));
+
 		AppDataSource.initialize()
 			.then(() => {
 				console.log('DATASOURCE HAS BEEN INITIALIZED');

--- a/src/entity/Category.ts
+++ b/src/entity/Category.ts
@@ -24,7 +24,7 @@ export class Category {
 		onDelete: 'CASCADE',
 		nullable: false,
 	})
-	userId: User;
+	user: User;
 
 	@JoinColumn()
 	@OneToMany(() => Todo, (todo) => todo.category)

--- a/src/entity/Diary.ts
+++ b/src/entity/Diary.ts
@@ -6,11 +6,14 @@ export class Diary {
 	@PrimaryGeneratedColumn()
 	id: number;
 
-	@Column()
+	@Column({ type: 'varchar', length: '100', nullable: false })
 	title: string;
 
-	@Column()
+	@Column({ type: 'varchar', length: '1000', nullable: false })
 	content: string;
+
+	@Column({ type: 'datetime', nullable: false, default: 'current timestamp' })
+	date: Date;
 
 	@ManyToOne(() => User, (user) => user.diaries, {
 		nullable: false,

--- a/src/entity/Diary.ts
+++ b/src/entity/Diary.ts
@@ -12,8 +12,8 @@ export class Diary {
 	@Column({ type: 'varchar', length: '1000', nullable: false })
 	content: string;
 
-	@Column({ type: 'datetime', nullable: false, default: 'current timestamp' })
-	date: Date;
+	@Column({ type: 'date', nullable: false })
+	targetDate: Date;
 
 	@ManyToOne(() => User, (user) => user.diaries, {
 		nullable: false,

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -24,7 +24,7 @@ export class User {
 	password: string;
 
 	@JoinColumn()
-	@OneToMany(() => Category, (category) => category.userId)
+	@OneToMany(() => Category, (category) => category.user)
 	categories: Category[];
 
 	@JoinColumn()


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- FEAT: Diary API 구축 완료 
- REFACTORING: 함수의 반환값 타입지정
- FIX: typeorm 메소드 사용법을 익혀가는 과정에서 발생한 relation 문제
 * 하지만 해결하지 못한 join된 테이블의 키를 조건으로 사용하는 법과 한 컬럼 데이터 제외하고 정보 불러오는 방법

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Diary data 반환 API
- 
2. Diary Create API
- 
3. Diary Delete API
- 
4. Diary Update API
- 

<br />

## :: 성장 포인트
- typeorm 메소드를 쉽게 할 수 있을 거라는 자신감이 있었는데, 꺼진 불도 다시 보자는 교훈을 얻었다...
- Relation을 하기 전까지는 괜찮았는데, 테이블 조인을 한 이후, 내부 조건을 설정하는 부분들이 좀 어려웠다.

<br />

### :: 추가 사항
- *  해결하지 못한 join된 테이블의 키를 조건으로 사용하는 법과 한 컬럼 데이터 제외하고 정보 불러오는 방법
